### PR TITLE
feat: 등록/탈퇴 명령어 추가, 등록한 유저에 한해서만 핑

### DIFF
--- a/functions/help.py
+++ b/functions/help.py
@@ -7,12 +7,17 @@ basic_commands = discord.Embed(
     title="처럼 도움말",
     description="처럼의 명령어에 대해서 소개합니다.",
     color=0xFFFFFF,
-).add_field(
+)
+basic_commands.add_field(
+    name="`/등록`, `/탈퇴`",
+    value="봇의 서비스에 등록하거나 탈퇴합니다. 서비스에 등록하면 타이머 기능은 자동으로 활성화됩니다.",
+    inline=False,
+)
+basic_commands.add_field(
     name="타이머",
     value="<@218010938807287808> (마냥)의 강화 메시지를 자동으로 감지하여 쿨타임이 채워지면 핑을 보내는 기능입니다.",
     inline=False,
 )
-
 
 class help(commands.Cog):
     @slash_command(description="처럼의 도움말을 전송합니다.")

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import utils.logging
 from discord.ext import commands
 import time
 from asyncio import sleep
+import pickle
 
 dotenv.load_dotenv()
 utils.logging.setup_logging()

--- a/main.py
+++ b/main.py
@@ -45,15 +45,113 @@ async def on_message(message):
             message.reference.channel_id
         )
         usercommand = await channel.fetch_message(message.reference.message_id)
-        if message.content.startswith(onemin_tuple):
-            logger.info("Message detected.")
-            await sleep(60)
-            await channel.send(f"<@{usercommand.author.id}>님, 강화 쿨타임이 지났습니다.")
-        elif message.content.startswith(tenmin_tuple):
-            await sleep(600)
-            await channel.send(f"<@{usercommand.author.id}>님, 강화 쿨타임이 지났습니다.")
-        else:
-            pass
+        if os.path.isfile(f"{usercommand.author.id}.pkl"):
+            if message.content.startswith(onemin_tuple):
+                logger.info("Message detected.")
+                await sleep(60)
+                await channel.send(f"<@{usercommand.author.id}>님, 강화 쿨타임이 지났습니다.")
+            elif message.content.startswith(tenmin_tuple):
+                await sleep(600)
+                await channel.send(f"<@{usercommand.author.id}>님, 강화 쿨타임이 지났습니다.")
+            else:
+                pass
+
+# register / delete ID - https://github.com/Whitetiger0423/CutePoint main.py e57b7af (lazy)
+@bot.slash_command(description="유저 정보를 등록합니다.")
+async def 등록(ctx):
+    if os.path.isfile(f"{ctx.user.id}.pkl") == False:
+        embed = discord.Embed(
+            title="등록", description="봇의 서비스에 등록합니다. 동의하지 않을 경우 서비스 이용에 제한이 있을 수 있습니다."
+        )
+        embed.add_field(name="수집하는 정보", value="유저의 디스코드 id", inline=False)
+
+        class Button(discord.ui.View):
+            @discord.ui.button(label="⭕ 동의", style=discord.ButtonStyle.primary)
+            async def primary(
+                self, button: discord.ui.Button, interaction: discord.Interaction
+            ):
+                UserData = 1
+                if interaction.user.id == ctx.user.id:
+                    with open(f"{interaction.user.id}.pkl", "wb") as f:
+                        pickle.dump(UserData, f)
+                    new_embed = discord.Embed(
+                        title="등록 완료", description=""
+                    )
+                    new_embed.add_field(
+                        name="", value=f"<@!{interaction.user.id}>님, 등록을 완료하였습니다. 아이디는 {interaction.user.id}입니다."
+                    )
+                    self.disable_all_items()
+                    await interaction.response.edit_message(view=self, embed=new_embed)
+
+            @discord.ui.button(label="❌ 취소", style=discord.ButtonStyle.danger)
+            async def danger(
+                self, button: discord.ui.Button, interaction: discord.Interaction
+            ):
+                if interaction.user.id == ctx.user.id:
+                    new_embed = discord.Embed(
+                        title="등록 취소", description=""
+                    )
+                    new_embed.add_field(
+                        name="", value=f"등록이 취소되었습니다."
+                    )
+                    self.disable_all_items()
+                    await interaction.response.edit_message(view=self, embed=new_embed)
+        await ctx.respond(embed=embed, view=Button())
+
+    else:
+        embed = discord.Embed(title="등록된 유저", description="")
+        embed.add_field(
+            name="", value="이미 등록되었습니다. `/탈퇴` 명령어를 통해 탈퇴할 수 있습니다.", inline=False
+        )
+        await ctx.respond(embed=embed)
+
+
+@bot.slash_command(description="봇 서비스를 탈퇴합니다.")
+async def 탈퇴(ctx):
+    if os.path.isfile(f"{ctx.user.id}.pkl"):
+        embed = discord.Embed(
+            title="탈퇴", description="봇의 서비스를 탈퇴합니다. 탈퇴할 경우 모든 데이터가 파기되며, 복구하기 어렵습니다."
+        )
+        embed.add_field(
+            name="파기하는 정보", value="유저의 디스코드 id, 서비스 이용 중 가챠 기록", inline=False
+        )
+
+        class Button(discord.ui.View):
+            @discord.ui.button(label="⭕ 동의", style=discord.ButtonStyle.primary)
+            async def primary(
+                self, button: discord.ui.Button, interaction: discord.Interaction
+            ):
+                if interaction.user.id == ctx.user.id:
+                    os.remove(f"{interaction.user.id}.pkl")
+                    new_embed = discord.Embed(
+                        title="탈퇴 완료", description=""
+                    )
+                    new_embed.add_field(
+                        name="", value=f"<@!{interaction.user.id}>님, 탈퇴를 완료하였습니다."
+                    )
+                    self.disable_all_items()
+                    await interaction.response.edit_message(view=self, embed=new_embed)
+
+            @discord.ui.button(label="❌ 취소", style=discord.ButtonStyle.danger)
+            async def danger(
+                self, button: discord.ui.Button, interaction: discord.Interaction
+            ):
+                if interaction.user.id == ctx.user.id:
+                    new_embed = discord.Embed(
+                        title="탈퇴 취소", description=""
+                    )
+                    new_embed.add_field(
+                        name="", value=f"탈퇴가 취소되었습니다."
+                    )
+                    self.disable_all_items()
+                    await interaction.response.edit_message(view=self, embed=new_embed)
+
+        await ctx.respond(embed=embed, view=Button())
+
+    else:
+        embed = discord.Embed(title="등록하지 않은 유저", description="")
+        embed.add_field(name="", value="`/등록`을 통해 가입해주세요.", inline=False)
+        await ctx.respond(embed=embed)
 
 
 # Load Cogs


### PR DESCRIPTION
[다른 프로젝트의 코드](https://github.com/Whitetiger0423/CutePoint/blob/e57b7afdbdbc6656099bcc9135ff46afd4fed39c/main.py)에서 그대로 등록/탈퇴 명령어를 가져오고 핑할때마다 해당 유저의 파일이 있는지 확인하는 식으로 작동합니다.
나중에 아예 다른 방식으로 변경할 필요가 있습니다. 이번 기능 추가는 임시입니다.